### PR TITLE
updated method for static initialization of Config types

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -502,11 +502,11 @@ dependencies = [
  "hex-literal",
  "hkdf",
  "hmac",
- "lazy_static",
  "log",
  "mock_instant",
  "nix 0.25.0",
  "num_cpus",
+ "once_cell",
  "parking_lot",
  "pin-project",
  "prost",
@@ -564,11 +564,11 @@ dependencies = [
  "hmac",
  "http",
  "hyper",
- "lazy_static",
  "log",
  "mime",
  "mock_instant",
  "mockall",
+ "once_cell",
  "parking_lot",
  "psutil",
  "rand",
@@ -1442,9 +1442,9 @@ dependencies = [
 
 [[package]]
 name = "once_cell"
-version = "1.15.0"
+version = "1.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e82dad04139b71a90c080c8463fe0dc7902db5192d939bd0950f074d014339e1"
+checksum = "86f0b0d4bf799edbc74508c1e8bf170ff5f41238e5f8225603ca7caaae2b7860"
 
 [[package]]
 name = "opaque-debug"

--- a/backend/Cargo.toml
+++ b/backend/Cargo.toml
@@ -27,7 +27,7 @@ clap = { version = "3.0", features = ["derive"] }
 # For runtime and threading
 tokio = { version = "1", features = ["full"] }
 parking_lot = "0.12"
-lazy_static = "1.4"
+once_cell = "1.16.0"
 futures = "0.3"
 num_cpus = "1.13"
 

--- a/backend/src/http_server.rs
+++ b/backend/src/http_server.rs
@@ -488,10 +488,12 @@ mod http_server_tests {
     use std::time::Instant;
 
     use hex::{FromHex, ToHex};
-    use lazy_static::lazy_static;
+    use once_cell::sync::Lazy;
     use rand::{thread_rng, Rng};
 
     use calling_common::random_hex_string;
+
+    static CONFIG: Lazy<config::Config> = Lazy::new(|| config::default_test_config());
 
     use super::*;
 
@@ -657,9 +659,7 @@ mod http_server_tests {
 
     #[tokio::test]
     async fn test_authenticate() {
-        lazy_static! {
-            static ref CONFIG: config::Config = config::default_test_config();
-        }
+        
         let config = &CONFIG;
 
         let result = authenticate(config, "1:2");
@@ -708,9 +708,7 @@ mod http_server_tests {
 
     #[tokio::test]
     async fn test_parse_and_authenticate() {
-        lazy_static! {
-            static ref CONFIG: config::Config = config::default_test_config();
-        }
+        
         let config = &CONFIG;
 
         // Version 1: "username:1a:2b:1:"

--- a/backend/src/main.rs
+++ b/backend/src/main.rs
@@ -4,8 +4,6 @@
 //
 
 #[macro_use]
-extern crate lazy_static;
-#[macro_use]
 extern crate log;
 
 use std::sync::{atomic::AtomicBool, Arc};
@@ -23,11 +21,12 @@ use tokio::{
     signal::unix::{signal, SignalKind},
     sync::{mpsc, oneshot},
 };
+use once_cell::sync::Lazy;
 
-lazy_static! {
-    // Load the config and treat it as a read-only static value.
-    static ref CONFIG: config::Config = config::Config::parse();
-}
+
+// Load the config and treat it as a read-only static value.
+static CONFIG: Lazy<config::Config> = Lazy::new(|| config::Config::parse());
+
 
 #[rustfmt::skip]
 fn print_config(config: &'static config::Config) {

--- a/backend/src/metrics_server.rs
+++ b/backend/src/metrics_server.rs
@@ -23,6 +23,9 @@ use crate::{
     },
     sfu::Sfu,
 };
+use once_cell::sync::Lazy;
+
+static CURRENT_PROCESS: Lazy<Mutex<Process>> = Lazy::new(|| Mutex::new(Process::current().expect("Can't get current process")));
 
 pub async fn start(
     config: &'static config::Config,
@@ -197,10 +200,6 @@ fn get_value_metrics() -> Vec<(&'static str, f32)> {
 /// Gets a vector of (metric_names, values) for current process metrics
 fn get_process_metrics() -> Vec<(&'static str, f32)> {
     let mut value_metrics = Vec::new();
-
-    lazy_static::lazy_static! {
-        static ref CURRENT_PROCESS: Mutex<Process> = Mutex::new(Process::current().expect("Can't get current process"));
-    }
 
     let mut current_process = CURRENT_PROCESS.lock();
 

--- a/backend/src/sfu.rs
+++ b/backend/src/sfu.rs
@@ -874,7 +874,7 @@ mod sfu_tests {
     use std::{convert::TryFrom, net::IpAddr, ops::Add, str::FromStr, sync::Arc};
 
     use hex::{FromHex, ToHex};
-    use lazy_static::lazy_static;
+    use once_cell::sync::Lazy;
     use parking_lot::Mutex;
     use rand::{thread_rng, Rng};
 
@@ -906,9 +906,7 @@ mod sfu_tests {
         config
     }
 
-    lazy_static! {
-        static ref DEFAULT_CONFIG: config::Config = config::default_test_config();
-    }
+    static DEFAULT_CONFIG: Lazy<config::Config> = Lazy::new(|| config::default_test_config());
 
     fn new_sfu(now: Instant, config: &'static config::Config) -> Arc<Mutex<Sfu>> {
         Arc::new(Mutex::new(
@@ -1193,10 +1191,10 @@ mod sfu_tests {
 
     const TICK_PERIOD_MS: u64 = 100;
     const INACTIVITY_TIMEOUT_SECS: u64 = 30;
-    lazy_static! {
-        static ref CUSTOM_CONFIG: config::Config =
-            custom_config(TICK_PERIOD_MS, INACTIVITY_TIMEOUT_SECS);
-    }
+    
+    static CUSTOM_CONFIG: Lazy<config::Config> =
+            Lazy::new(|| custom_config(TICK_PERIOD_MS, INACTIVITY_TIMEOUT_SECS));
+    
 
     #[tokio::test]
     async fn test_remove_clients() {

--- a/backend/src/signaling_server.rs
+++ b/backend/src/signaling_server.rs
@@ -469,7 +469,7 @@ pub async fn start(
 mod signaling_server_tests {
     use std::convert::TryInto;
 
-    use lazy_static::lazy_static;
+    use once_cell::sync::Lazy;
     use tokio::sync::oneshot;
     use warp::test::request;
 
@@ -487,16 +487,14 @@ mod signaling_server_tests {
         "b25387a93fd65599bacae4a8f8726e9e818ecf0bec3360593fe542cdb8e611a3-7715148009648537058";
     const UFRAG: &str = "Ouub";
 
-    lazy_static! {
-        static ref DEFAULT_CONFIG: config::Config = config::default_test_config();
+    static DEFAULT_CONFIG: Lazy<config::Config> = Lazy::new(|| config::default_test_config());
 
         // Load a config with no signaling_ip set.
-        static ref BAD_IP_CONFIG: config::Config = {
+    static BAD_IP_CONFIG: Lazy<config::Config> = Lazy::new(|| {
             let mut config = config::default_test_config();
             config.signaling_ip = None;
             config
-        };
-    }
+    });
 
     fn new_sfu(now: Instant, config: &'static config::Config) -> Arc<Mutex<Sfu>> {
         Arc::new(Mutex::new(

--- a/frontend/Cargo.toml
+++ b/frontend/Cargo.toml
@@ -25,7 +25,8 @@ clap = { version = "3.0", features = ["derive"] }
 
 # For runtime and threading
 tokio = { version = "1", features = ["rt-multi-thread", "signal", "macros"] }
-lazy_static = "1.4"
+# lazy_static = "1.4"
+once_cell = "1.16.0"
 futures = "0.3"
 async-trait = "0.1.53"
 

--- a/frontend/src/api/v2.rs
+++ b/frontend/src/api/v2.rs
@@ -172,7 +172,7 @@ mod api_server_v2_tests {
     use hmac::Mac;
     use http::{header, Request};
     use hyper::Body;
-    use lazy_static::lazy_static;
+    use once_cell::sync::Lazy;
     use mockall::predicate::*;
     use mockall::Sequence;
     use tower::ServiceExt;
@@ -205,15 +205,13 @@ mod api_server_v2_tests {
     const BACKEND_ICE_PWD: &str = "backend-password";
     const BACKEND_DHE_PUBLIC_KEY: &str = "24c41251f82b1f3481cce4bdaab8976a";
 
-    lazy_static! {
-        static ref CONFIG: config::Config = {
+    static CONFIG: Lazy<config::Config> = Lazy::new(|| {
             let mut config = config::default_test_config();
             config.authentication_key = AUTH_KEY.to_string();
             config.region = LOCAL_REGION.to_string();
             config.regional_url_template = "https://<region>.test.com".to_string();
             config
-        };
-    }
+    });
 
     fn generate_signed_v2_password(
         user_id_hex: &str,

--- a/frontend/src/main.rs
+++ b/frontend/src/main.rs
@@ -4,9 +4,6 @@
 //
 
 #[macro_use]
-extern crate lazy_static;
-
-#[macro_use]
 extern crate log;
 
 use std::sync::Arc;
@@ -26,10 +23,11 @@ use tokio::{
     sync::{mpsc, oneshot},
 };
 
-lazy_static! {
-    // Load the config and treat it as a read-only static value.
-    static ref CONFIG: config::Config = config::Config::parse();
-}
+use once_cell::sync::Lazy;
+
+// Load the config and treat it as a read-only static value.
+static CONFIG: Lazy<config::Config> = Lazy::new(|| config::Config::parse());
+
 
 #[rustfmt::skip]
 fn print_config(config: &'static config::Config) {

--- a/frontend/src/metrics.rs
+++ b/frontend/src/metrics.rs
@@ -29,7 +29,7 @@ use log::*;
 use parking_lot::Mutex;
 use psutil::process::Process;
 use tokio::sync::oneshot::Receiver;
-
+use once_cell::sync::Lazy;
 use crate::{
     config::Config,
     frontend::Frontend,
@@ -230,9 +230,7 @@ fn get_value_metrics() -> Vec<(&'static str, f32)> {
 fn get_process_metrics() -> Vec<(&'static str, f32)> {
     let mut value_metrics = Vec::new();
 
-    lazy_static::lazy_static! {
-        static ref CURRENT_PROCESS: Mutex<Process> = Mutex::new(Process::current().expect("Can't get current process"));
-    }
+    static CURRENT_PROCESS: Lazy<Mutex<Process>> = Lazy::new(|| Mutex::new(Process::current().expect("Can't get current process")));
 
     let mut current_process = CURRENT_PROCESS.lock();
 

--- a/frontend/src/metrics/macros.rs
+++ b/frontend/src/metrics/macros.rs
@@ -11,7 +11,7 @@ use std::{
     },
 };
 
-use lazy_static::*;
+use once_cell::sync::Lazy;
 use parking_lot::Mutex;
 
 use crate::metrics::{
@@ -39,9 +39,8 @@ pub struct Report {
     pub events: Vec<EventReport>,
 }
 
-lazy_static! {
-    pub static ref __METRICS: Metrics = Metrics::new_enabled();
-}
+pub static __METRICS: Lazy<Metrics> = Lazy::new(|| Metrics::new_enabled());
+
 
 impl Metrics {
     fn new_enabled() -> Metrics {
@@ -135,10 +134,9 @@ impl Metrics {
 #[macro_export]
 macro_rules! reporter {
     ($name:expr, $options:expr) => {{
-        lazy_static::lazy_static! {
-            pub static ref __REPORTER: std::sync::Arc<$crate::metrics::NumericValueReporter> =
-                $crate::metrics::__METRICS.create_and_register_timer($name, $options);
-        };
+        pub static __REPORTER: once_cell::sync::Lazy<std::sync::Arc<$crate::metrics::NumericValueReporter>> =
+                once_cell::sync::Lazy::new(|| $crate::metrics::__METRICS.create_and_register_timer($name, $options));
+
         &__REPORTER
     }};
 }
@@ -146,10 +144,9 @@ macro_rules! reporter {
 #[macro_export]
 macro_rules! event_reporter {
     ($name:expr) => {{
-        lazy_static::lazy_static! {
-            pub static ref __REPORTER: std::sync::Arc<$crate::metrics::EventCountReporter> =
-                $crate::metrics::__METRICS.create_and_register_event($name);
-        };
+        pub static __REPORTER: once_cell::sync::Lazy<std::sync::Arc<$crate::metrics::EventCountReporter>> =
+                once_cell::sync::Lazy::new(|| $crate::metrics::__METRICS.create_and_register_event($name));
+                
         &__REPORTER
     }};
 }


### PR DESCRIPTION
using `once_cell` instead of `lazy_static` block macro for initializing & setting global/local statics 


1. Updated Cargo.toml in `frontend` & `backend`

2.  Applied substitution in place of 

    ```rust
    lazy_static! {
        // Load the config and treat it as a read-only static value.
        static ref CONFIG: config::Config = config::Config::parse();
    }
    ```
    assignment into the static using `Lazy::new()`  which accepts a function/closure initializer, this is present under `once_cell::sync::Lazy` 

    ```rust
    use once_cell::sync::Lazy;
    // Load the config and treat it as a read-only static value.
    static CONFIG: Lazy<config::Config> = Lazy::new(|| config::Config::parse());
    ```

    this modification was applied across multiple files within `backend` & `Frontend` folder

