### PR TITLE
Convert certain methods from Option type to Result type

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -48,6 +48,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "ahash"
+version = "0.8.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cd7d5a2cecb58716e47d67d5703a249964b14c7be1ec3cad3affc295b2d1c35d"
+dependencies = [
+ "cfg-if",
+ "getrandom 0.2.8",
+ "once_cell",
+ "version_check",
+ "zerocopy",
+]
+
+[[package]]
 name = "aho-corasick"
 version = "0.7.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -81,7 +94,7 @@ checksum = "e4655ae1a7b0cdf149156f780c5bf3f1352bc53cbd9e0a361a7ef7b22947e965"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -92,7 +105,7 @@ checksum = "1cd7fce9ba8c3c042128ce72d8b2ddbf3a05747efb67ea0313c635e10bda47a2"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -558,6 +571,7 @@ dependencies = [
  "accounting-allocator",
  "aes",
  "aes-gcm",
+ "ahash",
  "anyhow",
  "async-stream",
  "axum",
@@ -706,7 +720,7 @@ dependencies = [
  "proc-macro-error",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -1016,7 +1030,7 @@ checksum = "95a73af87da33b5acf53acfebdc339fe592ecf5357ac7c0a7734ab9d8c876a70"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -1469,7 +1483,7 @@ dependencies = [
  "cfg-if",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -1636,7 +1650,7 @@ checksum = "069bdb1e05adc7a8990dce9cc75370895fbe4e3d58b9b73bf1aee56359344a55"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -1706,7 +1720,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e97e3215779627f01ee256d2fad52f3d95e8e1c11e9fc6fd08f7cd455d5d5c78"
 dependencies = [
  "proc-macro2",
- "syn",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -1718,7 +1732,7 @@ dependencies = [
  "proc-macro-error-attr",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.109",
  "version_check",
 ]
 
@@ -1735,9 +1749,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.51"
+version = "1.0.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d727cae5b39d21da60fa540906919ad737832fe0b1c165da3a34d6548c849d6"
+checksum = "134c189feb4956b20f6f547d2cf727d4c0fe06722b20a0eec87ed445a97f92da"
 dependencies = [
  "unicode-ident",
 ]
@@ -1769,7 +1783,7 @@ dependencies = [
  "prost",
  "prost-types",
  "regex",
- "syn",
+ "syn 1.0.109",
  "tempfile",
  "which",
 ]
@@ -1784,7 +1798,7 @@ dependencies = [
  "itertools",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -1813,9 +1827,9 @@ dependencies = [
 
 [[package]]
 name = "quote"
-version = "1.0.23"
+version = "1.0.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8856d8364d252a14d474036ea1358d63c9e6965c8e5c1885c18f73d70bff9c7b"
+checksum = "5267fca4496028628a95160fc423a33e8b2e6af8a5302579e322e4b520293cae"
 dependencies = [
  "proc-macro2",
 ]
@@ -2049,7 +2063,7 @@ checksum = "af487d118eecd09402d70a5d72551860e788df87b464af30e5ea6a38c75c541e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -2200,6 +2214,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "syn"
+version = "2.0.38"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e96b79aaa137db8f61e26363a0c9b47d8b4ec75da28b7d1d614c2303e232408b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
+
+[[package]]
 name = "sync_wrapper"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2213,7 +2238,7 @@ checksum = "f36bdaa60a83aca3921b5259d5400cbf5e90fc51931376a9bd4a0eb79aa7210f"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.109",
  "unicode-xid",
 ]
 
@@ -2268,7 +2293,7 @@ checksum = "1fb327af4685e4d03fa8cbcf1716380da910eeb2bb8be417e7f9fd3fb164f36f"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -2325,7 +2350,7 @@ checksum = "d266c00fde287f55d3f1c3e96c500c362a2b8c695076ec180f27918820bc6df8"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -2432,7 +2457,7 @@ checksum = "4017f8f45139870ca7e672686113917c71c7a6e02d4924eda67186083c03081a"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -2551,7 +2576,7 @@ dependencies = [
  "once_cell",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.109",
  "wasm-bindgen-shared",
 ]
 
@@ -2573,7 +2598,7 @@ checksum = "2aff81306fcac3c7515ad4e177f521b5c9a15f2b08f4e32d823066102f35a5f6"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.109",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
@@ -2754,6 +2779,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4d25c75bf9ea12c4040a97f829154768bbbce366287e2dc044af160cd79a13fd"
 
 [[package]]
+name = "zerocopy"
+version = "0.7.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4c19fae0c8a9efc6a8281f2e623db8af1db9e57852e04cde3e754dd2dc29340f"
+dependencies = [
+ "zerocopy-derive",
+]
+
+[[package]]
+name = "zerocopy-derive"
+version = "0.7.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc56589e9ddd1f1c28d4b4b5c773ce232910a6bb67a70133d61c9e347585efe9"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.38",
+]
+
+[[package]]
 name = "zeroize"
 version = "1.5.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2770,6 +2815,6 @@ checksum = "44bf07cb3e50ea2003396695d58bf46bc9887a1f362260446fad6bc4e79bd36c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.109",
  "synstructure",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -48,19 +48,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "ahash"
-version = "0.8.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cd7d5a2cecb58716e47d67d5703a249964b14c7be1ec3cad3affc295b2d1c35d"
-dependencies = [
- "cfg-if",
- "getrandom 0.2.8",
- "once_cell",
- "version_check",
- "zerocopy",
-]
-
-[[package]]
 name = "aho-corasick"
 version = "0.7.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -94,7 +81,7 @@ checksum = "e4655ae1a7b0cdf149156f780c5bf3f1352bc53cbd9e0a361a7ef7b22947e965"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 1.0.109",
+ "syn",
 ]
 
 [[package]]
@@ -105,7 +92,7 @@ checksum = "1cd7fce9ba8c3c042128ce72d8b2ddbf3a05747efb67ea0313c635e10bda47a2"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 1.0.109",
+ "syn",
 ]
 
 [[package]]
@@ -571,7 +558,6 @@ dependencies = [
  "accounting-allocator",
  "aes",
  "aes-gcm",
- "ahash",
  "anyhow",
  "async-stream",
  "axum",
@@ -720,7 +706,7 @@ dependencies = [
  "proc-macro-error",
  "proc-macro2",
  "quote",
- "syn 1.0.109",
+ "syn",
 ]
 
 [[package]]
@@ -1030,7 +1016,7 @@ checksum = "95a73af87da33b5acf53acfebdc339fe592ecf5357ac7c0a7734ab9d8c876a70"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 1.0.109",
+ "syn",
 ]
 
 [[package]]
@@ -1483,7 +1469,7 @@ dependencies = [
  "cfg-if",
  "proc-macro2",
  "quote",
- "syn 1.0.109",
+ "syn",
 ]
 
 [[package]]
@@ -1650,7 +1636,7 @@ checksum = "069bdb1e05adc7a8990dce9cc75370895fbe4e3d58b9b73bf1aee56359344a55"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 1.0.109",
+ "syn",
 ]
 
 [[package]]
@@ -1720,7 +1706,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e97e3215779627f01ee256d2fad52f3d95e8e1c11e9fc6fd08f7cd455d5d5c78"
 dependencies = [
  "proc-macro2",
- "syn 1.0.109",
+ "syn",
 ]
 
 [[package]]
@@ -1732,7 +1718,7 @@ dependencies = [
  "proc-macro-error-attr",
  "proc-macro2",
  "quote",
- "syn 1.0.109",
+ "syn",
  "version_check",
 ]
 
@@ -1783,7 +1769,7 @@ dependencies = [
  "prost",
  "prost-types",
  "regex",
- "syn 1.0.109",
+ "syn",
  "tempfile",
  "which",
 ]
@@ -1798,7 +1784,7 @@ dependencies = [
  "itertools",
  "proc-macro2",
  "quote",
- "syn 1.0.109",
+ "syn",
 ]
 
 [[package]]
@@ -2063,7 +2049,7 @@ checksum = "af487d118eecd09402d70a5d72551860e788df87b464af30e5ea6a38c75c541e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 1.0.109",
+ "syn",
 ]
 
 [[package]]
@@ -2214,17 +2200,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "syn"
-version = "2.0.38"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e96b79aaa137db8f61e26363a0c9b47d8b4ec75da28b7d1d614c2303e232408b"
-dependencies = [
- "proc-macro2",
- "quote",
- "unicode-ident",
-]
-
-[[package]]
 name = "sync_wrapper"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2238,7 +2213,7 @@ checksum = "f36bdaa60a83aca3921b5259d5400cbf5e90fc51931376a9bd4a0eb79aa7210f"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 1.0.109",
+ "syn",
  "unicode-xid",
 ]
 
@@ -2293,7 +2268,7 @@ checksum = "1fb327af4685e4d03fa8cbcf1716380da910eeb2bb8be417e7f9fd3fb164f36f"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 1.0.109",
+ "syn",
 ]
 
 [[package]]
@@ -2350,7 +2325,7 @@ checksum = "d266c00fde287f55d3f1c3e96c500c362a2b8c695076ec180f27918820bc6df8"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 1.0.109",
+ "syn",
 ]
 
 [[package]]
@@ -2457,7 +2432,7 @@ checksum = "4017f8f45139870ca7e672686113917c71c7a6e02d4924eda67186083c03081a"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 1.0.109",
+ "syn",
 ]
 
 [[package]]
@@ -2576,7 +2551,7 @@ dependencies = [
  "once_cell",
  "proc-macro2",
  "quote",
- "syn 1.0.109",
+ "syn",
  "wasm-bindgen-shared",
 ]
 
@@ -2598,7 +2573,7 @@ checksum = "2aff81306fcac3c7515ad4e177f521b5c9a15f2b08f4e32d823066102f35a5f6"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 1.0.109",
+ "syn",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
@@ -2779,26 +2754,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4d25c75bf9ea12c4040a97f829154768bbbce366287e2dc044af160cd79a13fd"
 
 [[package]]
-name = "zerocopy"
-version = "0.7.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c19fae0c8a9efc6a8281f2e623db8af1db9e57852e04cde3e754dd2dc29340f"
-dependencies = [
- "zerocopy-derive",
-]
-
-[[package]]
-name = "zerocopy-derive"
-version = "0.7.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc56589e9ddd1f1c28d4b4b5c773ce232910a6bb67a70133d61c9e347585efe9"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.38",
-]
-
-[[package]]
 name = "zeroize"
 version = "1.5.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2815,6 +2770,6 @@ checksum = "44bf07cb3e50ea2003396695d58bf46bc9887a1f362260446fad6bc4e79bd36c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 1.0.109",
+ "syn",
  "synstructure",
 ]

--- a/backend/Cargo.toml
+++ b/backend/Cargo.toml
@@ -43,6 +43,9 @@ hex = { version = "0.4", features = ["serde"] }
 serde = { version = "1.0", features = ["derive"] }
 prost = "0.11"
 
+# Hashing algorithm 
+ahash = "0.8.4"
+
 # For common
 sha2 = "0.10"
 

--- a/backend/Cargo.toml
+++ b/backend/Cargo.toml
@@ -43,9 +43,6 @@ hex = { version = "0.4", features = ["serde"] }
 serde = { version = "1.0", features = ["derive"] }
 prost = "0.11"
 
-# Hashing algorithm 
-ahash = "0.8.4"
-
 # For common
 sha2 = "0.10"
 

--- a/backend/src/connection.rs
+++ b/backend/src/connection.rs
@@ -94,7 +94,6 @@ pub enum ConnectionError {
 
     #[error("Invalid outgoing address type")]
     InvalidOutgoingAddressType,
-    // Add more error variants for other scenarios as needed
 }
 
 struct Ice {

--- a/backend/src/connection.rs
+++ b/backend/src/connection.rs
@@ -274,7 +274,7 @@ impl Connection {
         let rtp_endpoint = &mut self.rtp.endpoint;
         rtp_endpoint
             .receive_rtp(incoming_packet, now)
-            .or_else(|e| Err(IceError::ReceivedInvalidRtp))
+            .map_err(|_e| IceError::ReceivedInvalidRtp)
     }
 
     /// Decrypts an incoming RTCP packet and processes it.
@@ -292,7 +292,7 @@ impl Connection {
         let rtp_endpoint = &mut self.rtp.endpoint;
         let rtcp = rtp_endpoint
             .receive_rtcp(incoming_packet, now)
-            .or_else(|e| Err(IceError::ReceivedInvalidRtcp))?;
+            .map_err(|_e| IceError::ReceivedInvalidRtcp)?;
 
         let new_target_send_rate = self
             .congestion_control
@@ -397,7 +397,6 @@ impl Connection {
     /// Creates an encrypted key frame request to be sent to
     /// Connection::outgoing_addr().
     /// Will return None if SRTCP encryption fails.
-    //TODO: Use Result instead of Option
     pub fn send_key_frame_request(
         &mut self,
         key_frame_request: rtp::KeyFrameRequest,
@@ -412,11 +411,10 @@ impl Connection {
         let rtp_endpoint = &mut self.rtp.endpoint;
         let rtcp_packet = rtp_endpoint
             .send_pli(key_frame_request.ssrc)
-            .or_else(|e| Err(ConnectionError::RtpError(e.to_string())))?;
+            .map_err(|e| ConnectionError::RtpError(e.to_string()))?;
         Ok((rtcp_packet, outgoing_addr))
     }
 
-    //TODO: Use Result instead of Option
     // It would make more sense to return a Vec of packets, since the outgoing address is fixed,
     // but that actually makes it more difficult for sfu.rs to aggregate the
     // results of calling this across many connections.

--- a/backend/src/rtp.rs
+++ b/backend/src/rtp.rs
@@ -1658,9 +1658,8 @@ impl Endpoint {
         now: Instant,
     ) -> Result<Packet<&'packet mut [u8]>, EndpointError> {
         // Header::parse will log a warning for every place where it fails to parse.
-        let header = Header::parse(encrypted).ok_or_else(|| EndpointError::UndeterminedError(
-            "Header parsing error".to_string(),
-        ))?;
+        let header = Header::parse(encrypted)
+            .ok_or_else(|| EndpointError::UndeterminedError("Header parsing error".to_string()))?;
 
         let tcc_seqnum = header
             .tcc_seqnum
@@ -2645,7 +2644,7 @@ mod test {
             )
             .unwrap();
         // Simulate never received
-        sent2.decrypt_in_place(&sender_key.rtp.key, &sender_key.rtp.salt);
+        let _ = sent2.decrypt_in_place(&sender_key.rtp.key, &sender_key.rtp.salt);
         assert_eq!(&[5, 6, 7], sent2.payload());
         assert_eq!(Some(2), sent2.tcc_seqnum);
 

--- a/backend/src/rtp.rs
+++ b/backend/src/rtp.rs
@@ -1586,8 +1586,8 @@ pub enum EndpointError {
     #[error("Undetermined Endpoint error: {0:?}")]
     UndeterminedError(String),
 }
-// Add more error variants for other scenarios as needed
 
+//TODO: Develop some way for performing cross error conversions
 // impl<T> std::convert::From<T> for EndpointError
 // where T: std::string::ToString
 // {

--- a/backend/src/sfu.rs
+++ b/backend/src/sfu.rs
@@ -604,15 +604,15 @@ impl Sfu {
 
                     time_scope_us!("calling.sfu.handle_packet.rtcp.in_outgoing_connection_lock");
 
-                    let key_frame_res =
-                        outgoing_connection.send_key_frame_request(key_frame_request);
-
-                    if let Ok(key_frame_request) = key_frame_res {
-                        outgoing_packets.push(key_frame_request);
-                    } else if let Err(_e) = key_frame_res {
-                        return Err(SfuError::ConnectionError(
-                            connection::IceError::ReceivedInvalidRtp,
-                        ));
+                    match outgoing_connection.send_key_frame_request(key_frame_request) {
+                        Ok(key_frame_request) => {
+                            outgoing_packets.push(key_frame_request);
+                        }
+                        Err(_e) => {
+                            return Err(SfuError::ConnectionError(
+                                connection::IceError::ReceivedInvalidRtp,
+                            ));
+                        }
                     }
                 }
             }

--- a/backend/src/sfu.rs
+++ b/backend/src/sfu.rs
@@ -604,15 +604,15 @@ impl Sfu {
 
                     time_scope_us!("calling.sfu.handle_packet.rtcp.in_outgoing_connection_lock");
 
-                    let key_frame_res = outgoing_connection.send_key_frame_request(key_frame_request);
+                    let key_frame_res =
+                        outgoing_connection.send_key_frame_request(key_frame_request);
 
-                    if let Ok(key_frame_request) =
-                        key_frame_res
-                    {
+                    if let Ok(key_frame_request) = key_frame_res {
                         outgoing_packets.push(key_frame_request);
-                    }
-                    else if let Err(e) = key_frame_res {
-                        return Err(SfuError::ConnectionError(connection::IceError::ReceivedInvalidRtp));
+                    } else if let Err(e) = key_frame_res {
+                        return Err(SfuError::ConnectionError(
+                            connection::IceError::ReceivedInvalidRtp,
+                        ));
                     }
                 }
             }
@@ -853,8 +853,8 @@ impl Sfu {
                     self.connection_by_id.get_mut(&outgoing_connection_id)
                 {
                     let mut outgoing_connection = outgoing_connection.lock();
-             
-                    if let Ok(key_frame_request) = 
+
+                    if let Ok(key_frame_request) =
                         outgoing_connection.send_key_frame_request(key_frame_request)
                     {
                         packets_to_send.push(key_frame_request);

--- a/backend/src/sfu.rs
+++ b/backend/src/sfu.rs
@@ -502,7 +502,7 @@ impl Sfu {
                 time_scope_us!("calling.sfu.handle_packet.rtp.in_incoming_connection_lock");
                 let incoming_rtp = incoming_connection
                     .handle_rtp_packet(incoming_packet, Instant::now())
-                    .map_err(|e| SfuError::ConnectionError(e))?;
+                    .map_err(SfuError::ConnectionError)?;
                 (incoming_connection_id, incoming_rtp)
             };
 
@@ -566,7 +566,7 @@ impl Sfu {
                 time_scope_us!("calling.sfu.handle_packet.rtcp.in_incomin_connection_lock");
                 let result = incoming_connection
                     .handle_rtcp_packet(incoming_packet, Instant::now())
-                    .map_err(|e| SfuError::ConnectionError(e.into()))?;
+                    .map_err( SfuError::ConnectionError)?;
                 (incoming_connection_id, result)
             };
 
@@ -609,7 +609,7 @@ impl Sfu {
 
                     if let Ok(key_frame_request) = key_frame_res {
                         outgoing_packets.push(key_frame_request);
-                    } else if let Err(e) = key_frame_res {
+                    } else if let Err(_e) = key_frame_res {
                         return Err(SfuError::ConnectionError(
                             connection::IceError::ReceivedInvalidRtp,
                         ));

--- a/backend/src/sfu.rs
+++ b/backend/src/sfu.rs
@@ -566,7 +566,7 @@ impl Sfu {
                 time_scope_us!("calling.sfu.handle_packet.rtcp.in_incomin_connection_lock");
                 let result = incoming_connection
                     .handle_rtcp_packet(incoming_packet, Instant::now())
-                    .map_err( SfuError::ConnectionError)?;
+                    .map_err(SfuError::ConnectionError)?;
                 (incoming_connection_id, result)
             };
 


### PR DESCRIPTION
For improved error handling certain methods of codebase required `Result` type for appropriate error handling, instead of `Option `type

These changes for supporting error handling are still very experimental, and therefore require multiple inputs and guidance for refinement and improvements 😊, feel free to let me know.